### PR TITLE
refactor: remove deprecated columns from Events

### DIFF
--- a/web/db/migrate/20260214093258_remove_columns_from_events.rb
+++ b/web/db/migrate/20260214093258_remove_columns_from_events.rb
@@ -1,0 +1,7 @@
+class RemoveColumnsFromEvents < ActiveRecord::Migration[8.1]
+  def change
+    remove_column :events, :deprecated_cfp_start_at
+    remove_column :events, :deprecated_cfp_end_at
+    remove_column :events, :deprecated_cfp_site_url
+  end
+end

--- a/web/db/schema.rb
+++ b/web/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_02_14_091230) do
+ActiveRecord::Schema[8.1].define(version: 2026_02_14_093258) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -44,9 +44,6 @@ ActiveRecord::Schema[8.1].define(version: 2026_02_14_091230) do
 
   create_table "events", force: :cascade do |t|
     t.datetime "created_at", null: false
-    t.datetime "deprecated_cfp_end_at"
-    t.string "deprecated_cfp_site_url"
-    t.datetime "deprecated_cfp_start_at"
     t.datetime "end_at", null: false
     t.string "name", null: false
     t.string "site_url", null: false


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **保守作業**
  * イベント関連の非推奨なCall for Papers（CFP）フィールドを削除しました。データベーススキーマを最適化し、システムの保守性を向上させました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->